### PR TITLE
feat: add activeItemClass prop

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -40,6 +40,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     containerClass: "",
     sliderClass: "",
     itemClass: "",
+    activeItemClass: "",
     keyBoardControl: true,
     autoPlaySpeed: 3000,
     showDots: false,

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -27,6 +27,7 @@ const CarouselItems = ({
     children,
     infinite,
     itemClass,
+    activeItemClass,
     partialVisbile,
     partialVisible
   } = props;
@@ -73,11 +74,9 @@ const CarouselItems = ({
                     }px`
                   : "auto"
               }}
-              className={`react-multi-carousel-item ${
-                getIfSlideIsVisbile(index, state)
-                  ? "react-multi-carousel-item--active"
-                  : ""
-              } ${itemClass}`}
+              className={`react-multi-carousel-item ${itemClass} ${
+                getIfSlideIsVisbile(index, state) ? activeItemClass : ""
+              }`}
             >
               {child}
             </li>

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface CarouselProps {
   beforeChange?: (nextSlide: number, state: StateCallBack) => void; // Change callback before sliding everytime. `(previousSlide, currentState) => ...`
   sliderClass?: string; // Use this to style your own track list.
   itemClass?: string; // Use this to style your own Carousel item. For example add padding-left and padding-right
+  activeItemClass?: string; // Use this to style your own active Carousel item.
   containerClass?: string; // Use this to style the whole container. For example add padding to allow the "dots" or "arrows" to go to other places without being overflown.
   className?: string; // Use this to style the whole container with styled-components
   dotListClass?: string; // Use this to style the dot list.


### PR DESCRIPTION
This PR will add the `activeItemClass` prop, so we will be able to style the active item(s) without having to globally override the `react-multi-carousel-item--active` class.