### PR TITLE
chore: add base active item class

### DIFF
--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -75,7 +75,9 @@ const CarouselItems = ({
                   : "auto"
               }}
               className={`react-multi-carousel-item ${itemClass} ${
-                getIfSlideIsVisbile(index, state) ? activeItemClass : ""
+                getIfSlideIsVisbile(index, state)
+                  ? `react-multi-carousel-item--active ${activeItemClass}`
+                  : ""
               }`}
             >
               {child}


### PR DESCRIPTION
This PR will add the base active item class `react-multi-carousel-item--active`, so the class that comes from the `activeItemClass` will simply be appended.

```jsx
<Carousel activeItemClass="xpto">
  // ...slides
</Carousel>
```

```html
<li class="react-multi-carousel-item react-multi-carousel-item--active xpto">...</li>
```
