### PR TITLE
chore: remove autoPlay prop

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -42,7 +42,6 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     itemClass: "",
     activeItemClass: "",
     keyBoardControl: true,
-    autoPlaySpeed: 3000,
     showDots: false,
     renderDotsOutside: false,
     renderButtonGroupOutside: false,
@@ -157,8 +156,8 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     if (this.props.keyBoardControl) {
       window.addEventListener("keyup", this.onKeyUp as React.EventHandler<any>);
     }
-    if (this.props.autoPlay && this.props.autoPlaySpeed) {
-      this.autoPlay = setInterval(this.next, this.props.autoPlaySpeed);
+    if (this.props.autoPlaySpeedMs) {
+      this.autoPlay = setInterval(this.next, this.props.autoPlaySpeedMs);
     }
   }
 
@@ -293,7 +292,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     this.setItemsToShow(shouldCorrectItemPosition, true);
   }
   public componentDidUpdate(
-    { keyBoardControl, autoPlay, children }: CarouselProps,
+    { keyBoardControl, children }: CarouselProps,
     { containerWidth, domLoaded, currentSlide }: CarouselInternalState
   ): void {
     if (
@@ -314,12 +313,12 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     if (!keyBoardControl && this.props.keyBoardControl) {
       window.addEventListener("keyup", this.onKeyUp as React.EventHandler<any>);
     }
-    if (autoPlay && !this.props.autoPlay && this.autoPlay) {
+    if (!this.props.autoPlaySpeedMs && this.autoPlay) {
       clearInterval(this.autoPlay);
       this.autoPlay = undefined;
     }
-    if (!autoPlay && this.props.autoPlay && !this.autoPlay) {
-      this.autoPlay = setInterval(this.next, this.props.autoPlaySpeed);
+    if (this.props.autoPlaySpeedMs && !this.autoPlay) {
+      this.autoPlay = setInterval(this.next, this.props.autoPlaySpeedMs);
     }
     if (children.length !== this.props.children.length) {
       // this is for handling changing children only.
@@ -454,7 +453,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
         any
       >);
     }
-    if (this.props.autoPlay && this.autoPlay) {
+    if (this.autoPlay) {
       clearInterval(this.autoPlay);
       this.autoPlay = undefined;
     }
@@ -492,7 +491,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     const { clientX, clientY } = isMouseMoveEvent(e) ? e : e.touches[0];
     const diffX = this.initialX - clientX;
     const diffY = this.initialY - clientY;
-    if (!isMouseMoveEvent(e) && this.autoPlay && this.props.autoPlay) {
+    if (!isMouseMoveEvent(e) && this.autoPlay) {
       clearInterval(this.autoPlay);
       this.autoPlay = undefined;
     }
@@ -524,8 +523,8 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     }
   }
   public handleOut(e: React.MouseEvent | React.TouchEvent): void {
-    if (this.props.autoPlay && !this.autoPlay) {
-      this.autoPlay = setInterval(this.next, this.props.autoPlaySpeed);
+    if (this.props.autoPlaySpeedMs && !this.autoPlay) {
+      this.autoPlay = setInterval(this.next, this.props.autoPlaySpeedMs);
     }
     const shouldDisableOnMobile =
       e.type === "touchend" && !this.props.swipeable;
@@ -573,7 +572,7 @@ class Carousel extends React.Component<CarouselProps, CarouselInternalState> {
     }
   }
   public handleEnter(): void {
-    if (this.autoPlay && this.props.autoPlay) {
+    if (this.autoPlay && this.props.autoPlaySpeedMs) {
       clearInterval(this.autoPlay);
       this.autoPlay = undefined;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,8 +39,7 @@ export interface CarouselProps {
   dotListClass?: string; // Use this to style the dot list.
   keyBoardControl?: boolean;
   centerMode?: boolean; // show previous and next set of items partially
-  autoPlay?: boolean;
-  autoPlaySpeed?: number; // default 3000ms
+  autoPlaySpeedMs?: number;
   showDots?: boolean;
   renderDotsOutside?: boolean; // show dots outside of the container for custom styling.
   renderButtonGroupOutside?: boolean; // show buttonGroup outside of the container for custom styling.


### PR DESCRIPTION
This PR will remove the `autoPlay` prop, as suggested by @acostalima at https://github.com/moxystudio/rfcs-oss/pull/5#discussion_r369256368

Now, if the autoplay behaviour is desired, one only needs to pass a `number` to `autoPlaySpeedMs` to enable autoplay and define its speed in `ms`.

Before:

```jsx
<Carousel autoPlay autoPlaySpeed={9000}>
	// ...slides
</Carousel>
```

After:

```jsx
<Carousel autoPlaySpeedMs={9000}>
	// ...slides
</Carousel>
```
