### PR TITLE
feat: add slides filter

### DIFF
--- a/dev/pages/HomePage/HomePage.tsx
+++ b/dev/pages/HomePage/HomePage.tsx
@@ -41,7 +41,7 @@ class Index extends React.Component {
     }
     return { deviceType };
   }
-  state = { isMoving: false }
+  state = { isMoving: false };
   render() {
     const { classes } = this.props;
     const images = [
@@ -70,27 +70,35 @@ class Index extends React.Component {
       .map((item, index) => {
         return {
           image: images[index],
-          headline: 'w3js -> web front-end studio',
+          headline: "w3js -> web front-end studio",
           description: texts[index] || texts[0]
         };
       });
+
+    const isEven = (child: any, n: number) => {
+      return (n + 1) % 2 === 0;
+    };
+
+    const isOdd = (child: any, n: number) => {
+      return (n + 1) % 2 === 1;
+    };
+
     const responsive = {
       desktop: {
         breakpoint: { max: 3000, min: 1024 },
-        items: 3,
-        partialVisibilityGutter: 80
+        items: { slidesToShow: 3 },
+        partialVisibilityGutter: 40
       },
       tablet: {
         breakpoint: { max: 1024, min: 464 },
-        items: 2,
-        partialVisibilityGutter: 30
+        items: { slidesToShow: 2, slidesFilter: isEven }
       },
       mobile: {
         breakpoint: { max: 464, min: 0 },
-        items: 1,
-        partialVisibilityGutter: 30
+        items: { slidesToShow: 1, slidesFilter: isOdd }
       }
     };
+
     return (
       <div className={classes.root}>
         <Carousel
@@ -111,7 +119,9 @@ class Index extends React.Component {
           deviceType={this.props.deviceType}
         >
           {fakerData.map((card, index) => {
-            return <Card index={index} isMoving={this.state.isMoving} {...card} />;
+            return (
+              <Card index={index} isMoving={this.state.isMoving} {...card} />
+            );
           })}
         </Carousel>
 
@@ -125,14 +135,13 @@ class Index extends React.Component {
           showDots
           minimumTouchDrag={80}
           slidesToSlide={1}
-
           partialVisbile={true}
-          //infinite={true}
+          infinite={true}
           containerClass="container-with-dots"
           itemClass="image-item"
           deviceType={this.props.deviceType}
         >
-          {fakerData.slice(0,5).map(card => {
+          {fakerData.slice(0, 5).map(card => {
             return <Image url={card.image} alt={card.headline} />;
           })}
         </Carousel>

--- a/src/CarouselItems.tsx
+++ b/src/CarouselItems.tsx
@@ -22,7 +22,7 @@ const CarouselItems = ({
   clones,
   notEnoughChildren
 }: CarouselItemsProps) => {
-  const { itemWidth } = state;
+  const { itemWidth, slidesToRender } = state;
   const {
     children,
     infinite,
@@ -48,43 +48,41 @@ const CarouselItems = ({
   }
   return (
     <>
-      {(infinite ? clones : React.Children.toArray(children)).map(
-        (child, index) => {
-          return (
-            <li
-              key={index}
-              data-index={index}
-              onClick={() => {
-                if (props.focusOnSelect) {
-                  goToSlide(index);
-                }
-              }}
-              aria-hidden={getIfSlideIsVisbile(index, state) ? "false" : "true"}
-              style={{
-                flex: shouldRenderOnSSR ? `1 0 ${flexBisis}%` : "auto",
-                position: "relative",
-                width: domFullyLoaded
-                  ? `${
-                      // old wrongly spelt partialVisbile prop kept to not make changes breaking
-                      (partialVisbile || partialVisible) &&
-                      partialVisibilityGutter &&
-                      !notEnoughChildren
-                        ? itemWidth - partialVisibilityGutter
-                        : itemWidth
-                    }px`
-                  : "auto"
-              }}
-              className={`react-multi-carousel-item ${itemClass} ${
-                getIfSlideIsVisbile(index, state)
-                  ? `react-multi-carousel-item--active ${activeItemClass}`
-                  : ""
-              }`}
-            >
-              {child}
-            </li>
-          );
-        }
-      )}
+      {(infinite ? clones : slidesToRender).map((child, index) => {
+        return (
+          <li
+            key={index}
+            data-index={index}
+            onClick={() => {
+              if (props.focusOnSelect) {
+                goToSlide(index);
+              }
+            }}
+            aria-hidden={getIfSlideIsVisbile(index, state) ? "false" : "true"}
+            style={{
+              flex: shouldRenderOnSSR ? `1 0 ${flexBisis}%` : "auto",
+              position: "relative",
+              width: domFullyLoaded
+                ? `${
+                    // old wrongly spelt partialVisbile prop kept to not make changes breaking
+                    (partialVisbile || partialVisible) &&
+                    partialVisibilityGutter &&
+                    !notEnoughChildren
+                      ? itemWidth - partialVisibilityGutter
+                      : itemWidth
+                  }px`
+                : "auto"
+            }}
+            className={`react-multi-carousel-item ${itemClass} ${
+              getIfSlideIsVisbile(index, state)
+                ? `react-multi-carousel-item--active ${activeItemClass}`
+                : ""
+            }`}
+          >
+            {child}
+          </li>
+        );
+      })}
     </>
   );
 };

--- a/src/Dots.tsx
+++ b/src/Dots.tsx
@@ -22,29 +22,28 @@ const Dots = ({
   goToSlide,
   getState
 }: DotsTypes): React.ReactElement<any> | null => {
-  const { showDots, customDot, dotListClass, infinite, children } = props;
+  const { showDots, customDot, dotListClass, infinite } = props;
   if (!showDots || notEnoughChildren(state)) {
     return null;
   }
-  const { currentSlide, slidesToShow } = state;
+  const { currentSlide, slidesToShow, slidesToRender } = state;
   const slidesToSlide = getSlidesToSlide(state, props);
-  const childrenArr = React.Children.toArray(children);
   let numberOfDotsToShow: number;
   if (!infinite) {
     numberOfDotsToShow =
-      Math.ceil((childrenArr.length - slidesToShow) / slidesToSlide!) + 1;
+      Math.ceil((slidesToRender.length - slidesToShow) / slidesToSlide!) + 1;
   } else {
-    numberOfDotsToShow = Math.ceil(childrenArr.length / slidesToSlide!);
+    numberOfDotsToShow = Math.ceil(slidesToRender.length / slidesToSlide!);
   }
   const nextSlidesTable = getLookupTableForNextSlides(
     numberOfDotsToShow,
     state,
     props,
-    childrenArr
+    slidesToRender
   );
   const lookupTable = getOriginalIndexLookupTableByClones(
     slidesToShow,
-    childrenArr
+    slidesToRender
   );
   const currentSlides = lookupTable[currentSlide];
   return (
@@ -55,7 +54,7 @@ const Dots = ({
           let isActive;
           let nextSlide: number;
           if (!infinite) {
-            const maximumNextSlide = childrenArr.length - slidesToShow;
+            const maximumNextSlide = slidesToRender.length - slidesToShow;
             const possibileNextSlides = index * slidesToSlide!;
             const isAboutToOverSlide = possibileNextSlides > maximumNextSlide;
             nextSlide = isAboutToOverSlide
@@ -65,7 +64,7 @@ const Dots = ({
               nextSlide === currentSlide ||
               (currentSlide > nextSlide &&
                 currentSlide < nextSlide + slidesToSlide! &&
-                currentSlide < childrenArr.length - slidesToShow);
+                currentSlide < slidesToRender.length - slidesToShow);
           } else {
             nextSlide = nextSlidesTable[index];
             const cloneIndex = lookupTable[nextSlide];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
 import * as React from "react";
+type SlidesFilter = (child: any, n: number) => boolean;
 export interface ResponsiveType {
   [key: string]: {
     breakpoint: { max: number; min: number };
-    items: number;
+    items: { slidesToShow: number; slidesFilter?: SlidesFilter };
     partialVisibilityGutter?: number; // back-ward compatible, because previously there has been a typo
     paritialVisibilityGutter?: number;
     slidesToSlide?: number;
@@ -58,7 +59,6 @@ export interface CarouselProps {
   additionalTransfrom?: number; // this is only used if you want to add additional transfrom to the current transform
 }
 
-
 export type StateCallBack = CarouselInternalState;
 
 export type Direction = "left" | "right" | "" | undefined;
@@ -86,6 +86,8 @@ export interface CarouselInternalState {
   itemWidth: number;
   containerWidth: number;
   slidesToShow: number;
+  slidesFilter?: SlidesFilter;
+  slidesToRender: any[];
   currentSlide: number;
   totalItems: number;
   domLoaded: boolean;


### PR DESCRIPTION
This PR will add slides filter, so we will be able to pass a function to `slidesFilter` that has the following signature: `(child: any, n: number) => boolean`.

Note that it is also possible to look into the `props` of the children by accessing `child.prop` inside of the `slidesFilter` function:

```js
const hasAlt = (child, _) => Boolean(child.props.alt);
```

Usage:

```jsx

const isEven = (child: any, n: number) => {
  return (n + 1) % 2 === 0;
};

const isOdd = (child: any, n: number) => {
  return (n + 1) % 2 === 1;
};

const responsive = {
  desktop: {
    breakpoint: { max: 3000, min: 1024 },
    items: { slidesToShow: 3 },
    partialVisibilityGutter: 40
  },
  tablet: {
    breakpoint: { max: 1024, min: 464 },
    items: { slidesToShow: 2, slidesFilter: isEven }
  },
  mobile: {
    breakpoint: { max: 464, min: 0 },
    items: { slidesToShow: 1, slidesFilter: isOdd }
  }
};

return (
  <div className={classes.root}>
    <Carousel
      responsive={responsive}
      ssr
      showDots
      minimumTouchDrag={80}
      slidesToSlide={1}
      partialVisbile={true}
      infinite={true}
      containerClass="container-with-dots"
      itemClass="image-item"
      deviceType={this.props.deviceType}
    >
      {fakerData.slice(0, 5).map(card => {
        return <Image url={card.image} alt={card.headline} />;
      })}
    </Carousel>
  </div>
);
```